### PR TITLE
Fix: el header debe comenzar con bearer

### DIFF
--- a/middleware/Auth.js
+++ b/middleware/Auth.js
@@ -1,7 +1,8 @@
 
 export const isAutehnticated = (req, res, next) => {
-  if (req.headers.authorization) {
-    console.log('auth token', req.headers.authorization)
+  const { authorization } = req.headers
+  if (authorization) {
+    console.log('auth token', authorization.startsWith('Bearer'))
     return next()
   }
   res.status(401).end()


### PR DESCRIPTION
Revise que el header de auth empiece con Bearer respetando la documentacion de JWT